### PR TITLE
Updated deprocated use of flags and x86_64 support

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -11,10 +11,16 @@ solution "tmysql4"
 
 	language "C++"
 	location ( osname .."-".. _ACTION )
-	flags { "Symbols", "NoEditAndContinue", "NoPCH", "StaticRuntime", "EnableSSE" }
+	
+	flags {"NoPCH"}
+	symbols"On"
+	editandcontinue"Off"
+	vectorextensions"SSE"
+	staticruntime"On"
+	
 	targetdir ( "bin/" .. osname .. "/" )
 	includedirs { "include/GarrysMod", "include/" .. osname, "include/asio/asio/include" }
-	platforms{ "x32" }
+	platforms{ "x86","x86_64" }
 	libdirs { "library/" .. osname }
 
 	targetprefix ("gmsv_")
@@ -38,10 +44,16 @@ solution "tmysql4"
 			buildoptions { "-std=c++0x -pthread -Wl,-z,defs" }
 		end
 		defines { "NDEBUG" }
-		flags{ "Optimize", "FloatFast" }
+		optimize"On"
+		floatingpoint"Fast"
 	
 	project "tmysql4"
 		defines { "GMMODULE", "ENABLE_QUERY_TIMERS" }
 		files { "src/**.*", "include/GarrysMod/**.*", "include/" .. osname .. "/**.*" }
 		kind "SharedLib"
 		
+		filter'platforms:x86'
+			architecture'x86'
+		filter'platforms:x64'
+			architecture'x86_64'
+		filter{}


### PR DESCRIPTION
Updated premake5.lua to not use deprocated use of flags and added option for compiling x86_64 instead of just x86 only