### PR TITLE
remove unused variable

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -5,8 +5,6 @@
 
 using namespace GarrysMod::Lua;
 
-unsigned int database_index = 1;
-
 Database::Database(std::string host, std::string user, std::string pass, std::string db, unsigned int port, std::string socket, unsigned long flags, int callback)
 	: m_strHost(host), m_strUser(user), m_strPass(pass), m_strDB(db), m_iPort(port), m_strSocket(socket), m_iClientFlags(flags), m_iCallback(callback), m_bIsConnected(false), m_MySQL(NULL)
 {


### PR DESCRIPTION
Removed variable not referenced anywhere else

Not sure if you meant to do this but you will have to remove private from DatabaseAction or fix it some other way. Also TriggerCallback has not been defined yet in the Query class.