### PR TITLE
fix m_iAffected

### DIFF
--- a/src/result.cpp
+++ b/src/result.cpp
@@ -69,11 +69,6 @@ Result::Result(PStatement* pStmt, double LastID, double Affected) :
 		return;
 	}
 
-	if (m_iAffected == ((uint64_t)-1)) { // sometimes it is (uint64_t)-1 in that case initialize the values again here
-		m_iLastID = mysql_stmt_insert_id(stmt);
-		m_iAffected = mysql_stmt_affected_rows(stmt);
-	}
-
 	int colCount = mysql_stmt_field_count(stmt);
 	int rowCount = mysql_stmt_num_rows(stmt);
 	Resize(colCount, rowCount);

--- a/src/result.h
+++ b/src/result.h
@@ -11,7 +11,7 @@ class Result
 public:
 	Result(int errNo, const char* errStr) : m_iError(errNo), m_strError(errStr) { }
 	Result(MYSQL* mysql);
-	Result(PStatement* pStmt);
+	Result(PStatement* pStmt, double LastID, double Affected);
 	~Result();
 
 	void PopulateLuaTable(lua_State* state, bool useNumbers);

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -53,9 +53,11 @@ void PStatement::Execute(MYSQL_BIND* binds, DatabaseAction* action) {
 		action->AddResult(new Result(errorno, mysql_stmt_error(m_stmt)));
 	else {
 		int status = 0;
+		double m_iLastID = mysql_stmt_insert_id(m_stmt); // init values here to reduce overhead, once they leave scope they seem to be invalid
+		double m_iAffected = mysql_stmt_affected_rows(m_stmt);
 		while (status != -1) {
 			mysql_stmt_store_result(m_stmt);
-			action->AddResult(new Result(this));
+			action->AddResult(new Result(this, m_iLastID, m_iAffected));
 			status = mysql_stmt_next_result(m_stmt);
 		}
 	}

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -53,11 +53,9 @@ void PStatement::Execute(MYSQL_BIND* binds, DatabaseAction* action) {
 		action->AddResult(new Result(errorno, mysql_stmt_error(m_stmt)));
 	else {
 		int status = 0;
-		double m_iLastID = mysql_stmt_insert_id(m_stmt); // init values here to reduce overhead, once they leave scope they seem to be invalid
-		double m_iAffected = mysql_stmt_affected_rows(m_stmt);
 		while (status != -1) {
 			mysql_stmt_store_result(m_stmt);
-			action->AddResult(new Result(this, m_iLastID, m_iAffected));
+			action->AddResult(new Result(this, mysql_stmt_insert_id(m_stmt), mysql_stmt_affected_rows(m_stmt))); // init values here once they leave scope they seem to be invalid
 			status = mysql_stmt_next_result(m_stmt);
 		}
 	}


### PR DESCRIPTION
Took a few commits but this should fix m_iAffected from being a random floating point.
mysql_stmt_affected_rows seems to be valid within the scope of mysql_stmt_execute and also sometimes it requires to be within mysql_stmt_store_result.

If you want to write it in your own way please do so.

I have not tested if this patch will work as is. You might need to edit a few things still after this.