### PR TITLE
Add extra functions

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -291,12 +291,15 @@ int Database::lua__tostring(lua_State* state)
 	LUA->CheckType(1, tmysql::iDatabaseMTID);
 
 	Database* mysqldb = LUA->GetUserType<Database>(1, tmysql::iDatabaseMTID);
-
-	char buff[100] = { 0 };
-	sprintf_s(buff, 100, "[Tmysql4 database: %s]", mysqldb->m_strDB);
-	LUA->PushString(buff);
-
-	return 1;
+	
+	if (mysqldb != nullptr) {
+		char buff[100] = { 0 };
+		sprintf_s(buff, 100, "[Tmysql database: %s]", mysqldb->m_strDB);
+		LUA->PushString(buff);
+		return 1;
+	}
+	
+	return 0;
 }
 
 int Database::lua_IsValid(lua_State* state)
@@ -455,9 +458,12 @@ int Database::lua_GetDatabase(lua_State* state)
 
 	Database* mysqldb = LUA->GetUserType<Database>(1, tmysql::iDatabaseMTID);
 	
-	LUA->PushString(mysqldb->m_strDB);
+	if (mysqldb != nullptr) {
+		LUA->PushString(mysqldb->m_strDB);
+		return 1;
+	}
 	
-	return 1;
+	return 0;
 }
 
 int Database::lua_GetHostInfo(lua_State* state)

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -285,6 +285,20 @@ int Database::lua___gc(lua_State* state)
 	return 0;
 
 }
+
+int Database::lua__tostring(lua_State* state)
+{
+	LUA->CheckType(1, tmysql::iDatabaseMTID);
+
+	Database* mysqldb = LUA->GetUserType<Database>(1, tmysql::iDatabaseMTID);
+
+	char buff[100] = { 0 };
+	sprintf_s(buff, 100, "[Tmysql4 database: %s]", mysqldb->m_strDB);
+	LUA->PushString(buff);
+
+	return 1;
+}
+
 int Database::lua_IsValid(lua_State* state)
 {
 	LUA->CheckType(1, tmysql::iDatabaseMTID);
@@ -432,6 +446,17 @@ int Database::lua_GetServerInfo(lua_State* state)
 	}
 
 	LUA->PushString(mysqldb->GetServerInfo());
+	return 1;
+}
+
+int Database::lua_GetDatabase(lua_State* state)
+{
+	LUA->CheckType(1, tmysql::iDatabaseMTID);
+
+	Database* mysqldb = LUA->GetUserType<Database>(1, tmysql::iDatabaseMTID);
+	
+	LUA->PushString(mysqldb->m_strDB);
+	
 	return 1;
 }
 

--- a/src/database.h
+++ b/src/database.h
@@ -78,12 +78,14 @@ public:
 
 	// Lua metamethods
 	static int		lua___gc(lua_State* state);
+	static int		lua__tostring(lua_State* state);
 	static int		lua_IsValid(lua_State* state);
 	static int		lua_Query(lua_State* state);
 	static int		lua_Prepare(lua_State* state);
 	static int		lua_Escape(lua_State* state);
 	static int		lua_SetOption(lua_State* state);
 	static int		lua_GetServerInfo(lua_State* state);
+	static int		lua_GetDatabase(lua_State* state);
 	static int		lua_GetHostInfo(lua_State* state);
 	static int		lua_GetServerVersion(lua_State* state);
 	static int		lua_Connect(lua_State* state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,13 +162,12 @@ GMOD_MODULE_OPEN()
 	{
 		LUA->Push(-1);
 		LUA->SetField(-2, "__index");
-
 		LUA->PushCFunction(Database::lua___gc);
 		LUA->SetField(-2, "__gc");
-
+		LUA->PushCFunction(Database::lua__tostring);
+		LUA->SetField(-2, "__tostring");
 		LUA->PushCFunction(Database::lua_IsValid);
 		LUA->SetField(-2, "IsValid");
-
 		LUA->PushCFunction(Database::lua_Query);
 		LUA->SetField(-2, "Query");
 		LUA->PushCFunction(Database::lua_Prepare);
@@ -179,6 +178,8 @@ GMOD_MODULE_OPEN()
 		LUA->SetField(-2, "SetOption");
 		LUA->PushCFunction(Database::lua_GetServerInfo);
 		LUA->SetField(-2, "GetServerInfo");
+		LUA->PushCFunction(Database::lua_GetDatabase);
+		LUA->SetField(-2, "GetDatabase");
 		LUA->PushCFunction(Database::lua_GetHostInfo);
 		LUA->SetField(-2, "GetHostInfo");
 		LUA->PushCFunction(Database::lua_GetServerVersion);
@@ -203,6 +204,9 @@ GMOD_MODULE_OPEN()
 
 		LUA->PushCFunction(PStatement::lua___gc);
 		LUA->SetField(-2, "__gc");
+
+		LUA->PushCFunction(PStatement::lua__tostring);
+		LUA->SetField(-2, "__tostring");
 
 		LUA->PushCFunction(PStatement::lua_Run);
 		LUA->SetField(-2, "__call");

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -102,7 +102,7 @@ int PStatement::lua___gc(lua_State* state)
 
 int PStatement::lua__tostring(lua_State* state)
 {
-	LUA->PushString("[Tmysql4 prepared statement]");
+	LUA->PushString("[Tmysql prepared statement]");
 	return 1;
 }
 

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -100,6 +100,12 @@ int PStatement::lua___gc(lua_State* state)
 	return 0;
 }
 
+int PStatement::lua__tostring(lua_State* state)
+{
+	LUA->PushString("[Tmysql4 prepared statement]");
+	return 1;
+}
+
 int PStatement::lua_IsValid(lua_State* state)
 {
 	LUA->CheckType(1, tmysql::iStatementMTID);

--- a/src/statement.h
+++ b/src/statement.h
@@ -18,6 +18,7 @@ public:
 	static int	lua_IsValid(lua_State* state);
 	static int	lua_GetArgCount(lua_State* state);
 	static int	lua_Run(lua_State* state);
+	static int	lua__tostring(lua_State* state);
 private:
 	Database*	m_database;
 	MYSQL_STMT* m_stmt;


### PR DESCRIPTION
__tostring to for the string library. print, string.format
db:GetDatabase in case you somehow forgot what the database is called. Mostly useful for tmysql.GetTable()