### PR TITLE
Fix tmysql4 crashing Windows GMod (not srcds) on disconnect from game

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -71,6 +71,7 @@ bool Database::Connect(std::string& error, bool isReconnect)
 
 void Database::Release(lua_State* state)
 {
+	io_thread->join();
 	io_thread.release();
 
 	if (m_MySQL != NULL)


### PR DESCRIPTION
Willox: i just know it's standard behaviour for std::thread's destructor to crash if you don't either join or detach it

![](https://cdn.discordapp.com/attachments/152162730244177920/802952768839090236/unknown.png)